### PR TITLE
Levene and Wilcoxon (paired samples) tests with optional parameters list

### DIFF
--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -57,7 +57,11 @@ def stat_test(box_data1, box_data2, test, **stats_params):
         formatted_output = "t-test paired samples, " \
                            "P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 'Wilcoxon':
-        zero_method = len(box_data1) <= 20 and "pratt" or "wilcox"
+        if "zero_method" in stats_params.keys():
+            zero_method = stats_params["zero_method"]
+            del stats_params["zero_method"]
+        else:
+            zero_method = len(box_data1) <= 20 and "pratt" or "wilcox"
         print("Using zero_method ", zero_method)
         stat, pval = stats.wilcoxon(
             box_data1, box_data2, zero_method=zero_method, **stats_params)

--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -16,6 +16,10 @@ DEFAULT = object()
 def stat_test(box_data1, box_data2, test):
     test_short_name = ''
     formatted_output = None
+    if test == 'Levene':
+        stat, pval = stats.levene(box_data1, box_data2)
+        testShortName = 'levene'
+        formattedOutput = "Levene test of variance, P_val={:.3e} stat={:.3e}".format(pval, stat)
     if test == 'Mann-Whitney':
         u_stat, pval = stats.mannwhitneyu(box_data1, box_data2, alternative='two-sided')
         test_short_name = 'M.W.W.'
@@ -43,6 +47,12 @@ def stat_test(box_data1, box_data2, test):
         stat, pval = stats.ttest_rel(a=box_data1, b=box_data2)
         test_short_name = 't-test_rel'
         formatted_output = "t-test paired samples, P_val={:.3e} stat={:.3e}".format(pval, stat)
+    elif test == 'Wilcoxon':
+        zero_method = len(box_data1) <= 20 and "pratt" or "wilcox"
+        print(zero_method)
+        stat, pval = stats.wilcoxon(box_data1, box_data2, zero_method=zero_method)
+        testShortName = 'Wilcoxon'
+        formattedOutput = "Wilcoxon test (paired samples), P_val={:.3e} stat={:.3e}".format(pval, stat)
     return pval, formatted_output, test_short_name
 
 

--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -1,6 +1,6 @@
-from matplotlib.text import Text
+# from matplotlib.text import Text
 import matplotlib.pyplot as plt
-from matplotlib import transforms, lines
+from matplotlib import lines
 import matplotlib.transforms as mtransforms
 from matplotlib.font_manager import FontProperties
 import numpy as np
@@ -13,68 +13,81 @@ from scipy import stats
 DEFAULT = object()
 
 
-def stat_test(box_data1, box_data2, test):
+def stat_test(box_data1, box_data2, test, **stats_params):
     test_short_name = ''
+    pval = None
     formatted_output = None
     if test == 'Levene':
-        stat, pval = stats.levene(box_data1, box_data2)
+        stat, pval = stats.levene(box_data1, box_data2, **stats_params)
         test_short_name = 'levene'
-        formatted_output = "Levene test of variance, P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = "Levene test of variance, " \
+                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 'Mann-Whitney':
-        u_stat, pval = stats.mannwhitneyu(box_data1, box_data2, alternative='two-sided')
+        u_stat, pval = stats.mannwhitneyu(
+            box_data1, box_data2, alternative='two-sided', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = ("Mann-Whitney-Wilcoxon test two-sided P_val={:.3e} U_stat={:.3e}"
-                           .format(pval, u_stat))
+        formatted_output = "Mann-Whitney-Wilcoxon test two-sided " \
+                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
     elif test == 'Mann-Whitney-gt':
-        u_stat, pval = stats.mannwhitneyu(box_data1, box_data2, alternative='greater')
+        u_stat, pval = stats.mannwhitneyu(
+            box_data1, box_data2, alternative='greater', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = ("Mann-Whitney-Wilcoxon test greater P_val={:.3e} U_stat={:.3e}"
-                           .format(pval, u_stat))
+        formatted_output = "Mann-Whitney-Wilcoxon test greater " \
+                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
     elif test == 'Mann-Whitney-ls':
-        u_stat, pval = stats.mannwhitneyu(box_data1, box_data2, alternative='less')
+        u_stat, pval = stats.mannwhitneyu(
+            box_data1, box_data2, alternative='less', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = ("Mann-Whitney-Wilcoxon test smaller P_val={:.3e} U_stat={:.3e}"
-                           .format(pval, u_stat))
+        formatted_output = "Mann-Whitney-Wilcoxon test smaller " \
+                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
     elif test == 't-test_ind':
-        stat, pval = stats.ttest_ind(a=box_data1, b=box_data2)
+        stat, pval = stats.ttest_ind(a=box_data1, b=box_data2, **stats_params)
         test_short_name = 't-test_ind'
-        formatted_output = "t-test independent samples, P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = "t-test independent samples, " \
+                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 't-test_welch':
-        stat, pval = stats.ttest_ind(a=box_data1, b=box_data2, equal_var=False)
+        stat, pval = stats.ttest_ind(
+            a=box_data1, b=box_data2, equal_var=False, **stats_params)
         test_short_name = 't-test_welch'
-        formatted_output = "Welch's t-test independent samples, P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = "Welch's t-test independent samples, " \
+                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 't-test_paired':
-        stat, pval = stats.ttest_rel(a=box_data1, b=box_data2)
+        stat, pval = stats.ttest_rel(a=box_data1, b=box_data2, **stats_params)
         test_short_name = 't-test_rel'
-        formatted_output = "t-test paired samples, P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = "t-test paired samples, " \
+                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 'Wilcoxon':
         zero_method = len(box_data1) <= 20 and "pratt" or "wilcox"
         print("Using zero_method ", zero_method)
-        stat, pval = stats.wilcoxon(box_data1, box_data2, zero_method=zero_method)
+        stat, pval = stats.wilcoxon(
+            box_data1, box_data2, zero_method=zero_method, **stats_params)
         test_short_name = 'Wilcoxon'
-        formatted_output = "Wilcoxon test (paired samples), P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = "Wilcoxon test (paired samples), " \
+                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
     return pval, formatted_output, test_short_name
 
 
 def pval_annotation_text(x, pvalue_thresholds):
-    singleValue = False
+    single_value = False
     if type(x) is np.array:
         x1 = x
     else:
         x1 = np.array([x])
-        singleValue = True
+        single_value = True
     # Sort the threshold array
-    pvalue_thresholds = pd.DataFrame(pvalue_thresholds).sort_values(by=0, ascending=False).values
+    pvalue_thresholds = pd.DataFrame(
+        pvalue_thresholds).sort_values(by=0, ascending=False).values
     x_annot = pd.Series(["" for _ in range(len(x1))])
     for i in range(0, len(pvalue_thresholds)):
-        if (i < len(pvalue_thresholds)-1):
-            condition = (x1 <= pvalue_thresholds[i][0]) & (pvalue_thresholds[i+1][0] < x1)
+        if i < len(pvalue_thresholds)-1:
+            condition = (x1 <= pvalue_thresholds[i][0]) & \
+                        (pvalue_thresholds[i+1][0] < x1)
             x_annot[condition] = pvalue_thresholds[i][1]
         else:
             condition = x1 < pvalue_thresholds[i][0]
             x_annot[condition] = pvalue_thresholds[i][1]
 
-    return x_annot if not singleValue else x_annot.iloc[0]
+    return x_annot if not single_value else x_annot.iloc[0]
 
 
 def simple_text(pval, pvalue_format, pvalue_thresholds, test_short_name=None):
@@ -103,15 +116,18 @@ def simple_text(pval, pvalue_format, pvalue_thresholds, test_short_name=None):
 
 
 def add_stat_annotation(ax,
-                        data=None, x=None, y=None, hue=None, order=None, hue_order=None,
-                        box_pairs=None,
-                        test='t-test_welch', text_format='star', pvalue_format_string=DEFAULT,
-                        loc='inside', show_test_name=True, pvalue_thresholds=DEFAULT,
-                        use_fixed_offset=False, line_offset_to_box=None, line_offset=None,
-                        line_height=0.02, text_offset=1, stack=True,
-                        color='0.2', linewidth=1.5, fontsize='medium', verbose=1):
+                        data=None, x=None, y=None, hue=None, order=None,
+                        hue_order=None, box_pairs=None, test='t-test_welch',
+                        text_format='star', pvalue_format_string=DEFAULT,
+                        loc='inside', show_test_name=True,
+                        pvalue_thresholds=DEFAULT, stats_params: dict = None,
+                        use_fixed_offset=False, line_offset_to_box=None,
+                        line_offset=None, line_height=0.02, text_offset=1,
+                        stack=True, color='0.2', linewidth=1.5,
+                        fontsize='medium', verbose=1):
     """
-    User should use the same argument for the data, x, y, hue, order, hue_order as the seaborn boxplot function.
+    User should use the same argument for the data, x, y, hue, order, hue_order
+    as the seaborn boxplot function.
 
     line_height is in axes fraction coordinates.
     text_offset is in points.
@@ -134,40 +150,35 @@ def add_stat_annotation(ax,
         """
         if box_plotter.plot_hues is None:
             cat = boxName
-            hueOffset = 0
+            hue_offset = 0
         else:
             cat = boxName[0]
             hue = boxName[1]
-            hueOffset = box_plotter.hue_offsets[box_plotter.hue_names.index(hue)]
+            hue_offset = box_plotter.hue_offsets[box_plotter.hue_names.index(hue)]
 
-        groupPos = box_plotter.group_names.index(cat)
-        boxPos = groupPos + hueOffset
-        return boxPos
-
+        group_pos = box_plotter.group_names.index(cat)
+        box_pos = group_pos + hue_offset
+        return box_pos
 
     def get_box_data(box_plotter, boxName):
         """
         boxName can be either a name "cat" or a tuple ("cat", "hue")
 
-        Here we really have to duplicate seaborn code, because there is not direct access to the
-        box_data in the BoxPlotter class.
+        Here we really have to duplicate seaborn code, because there is not
+        direct access to the box_data in the BoxPlotter class.
         """
-        if box_plotter.plot_hues is None:
-            cat = boxName
-        else:
-            cat = boxName[0]
-            hue = boxName[1]
+        cat = box_plotter.plot_hues is None and boxName or boxName[0]
 
-        i = box_plotter.group_names.index(cat)
-        group_data = box_plotter.plot_data[i]
+        index = box_plotter.group_names.index(cat)
+        group_data = box_plotter.plot_data[index]
 
         if box_plotter.plot_hues is None:
             # Draw a single box or a set of boxes
             # with a single level of grouping
             box_data = remove_na(group_data)
         else:
-            hue_level = hue
-            hue_mask = box_plotter.plot_hues[i] == hue_level
+            hue_level = boxName[1]
+            hue_mask = box_plotter.plot_hues[index] == hue_level
             box_data = remove_na(group_data[hue_mask])
 
         return box_data
@@ -191,25 +202,41 @@ def add_stat_annotation(ax,
 
     valid_list = ['inside', 'outside']
     if loc not in valid_list:
-        raise ValueError("loc value should be one of the following: {}.".format(', '.join(valid_list)))
-    valid_list = ['t-test_ind', 't-test_welch', 't-test_paired', 'Mann-Whitney', 'Mann-Whitney-gt', 'Mann-Whitney-ls']
+        raise ValueError(
+            "loc value should be one of the following: {}.".format(
+                ', '.join(valid_list)))
+    valid_list = ['full', 'simple', 'star']
+    if text_format not in valid_list:
+        raise ValueError(
+            "text_format value should be one of the following: {}.".format(
+                ', '.join(valid_list)))
+    valid_list = ['t-test_ind', 't-test_welch', 't-test_paired', 'Mann-Whitney',
+                  'Mann-Whitney-gt', 'Mann-Whitney-ls', 'Levene', 'Wilcoxon']
     if test not in valid_list:
-        raise ValueError("test value should be one of the following: {}.".format(', '.join(valid_list)))
+        raise ValueError(
+            "test value should be one of the following: {}.".format(
+                ', '.join(valid_list)))
 
     if verbose >= 1 and text_format == 'star':
         print("pvalue annotation legend:")
-        pvalue_thresholds = pd.DataFrame(pvalue_thresholds).sort_values(by=0, ascending=False).values
+        pvalue_thresholds = pd.DataFrame(pvalue_thresholds).sort_values(
+            by=0, ascending=False).values
         for i in range(0, len(pvalue_thresholds)):
-            if (i < len(pvalue_thresholds)-1):
-                print('{}: {:.2e} < p <= {:.2e}'.format(pvalue_thresholds[i][1], pvalue_thresholds[i+1][0], pvalue_thresholds[i][0]))
+            if i < len(pvalue_thresholds)-1:
+                print('{}: {:.2e} < p <= {:.2e}'.format(
+                    pvalue_thresholds[i][1], pvalue_thresholds[i+1][0],
+                    pvalue_thresholds[i][0]))
             else:
-                print('{}: p <= {:.2e}'.format(pvalue_thresholds[i][1], pvalue_thresholds[i][0]))
+                print('{}: p <= {:.2e}'.format(
+                    pvalue_thresholds[i][1], pvalue_thresholds[i][0]))
         print()
 
     # Create the same BoxPlotter object as seaborn's boxplot
     box_plotter = sns.categorical._BoxPlotter(x, y, hue, data, order, hue_order,
-                                              orient=None, width=.8, color=None, palette=None, saturation=.75,
-                                              dodge=True, fliersize=5, linewidth=None)
+                                              orient=None, width=.8, color=None,
+                                              palette=None, saturation=.75,
+                                              dodge=True, fliersize=5,
+                                              linewidth=None)
 
     ylim = ax.get_ylim()
     yrange = ylim[1] - ylim[0]
@@ -219,7 +246,8 @@ def add_stat_annotation(ax,
             line_offset = 0.05
             if line_offset_to_box is None:
                 line_offset_to_box = 0.06
-        elif loc == 'outside':
+        # 'outside', see valid_list
+        else:
             line_offset = 0.03
             if line_offset_to_box is None:
                 line_offset_to_box = line_offset
@@ -227,24 +255,22 @@ def add_stat_annotation(ax,
         if loc == 'inside':
             if line_offset_to_box is None:
                 line_offset_to_box = 0.06
-        elif loc == 'outside':
+        # 'outside', see valid_list
+        else:
             line_offset_to_box = line_offset
     y_offset = line_offset*yrange
     y_offset_to_box = line_offset_to_box*yrange
 
     y_stack = []
-    annList = []
+    ann_list = []
     test_result_list = []
-    for box1, box2 in box_pairs:
 
-        valid = None
+    for box1, box2 in box_pairs:
         group_names = box_plotter.group_names
         hue_names = box_plotter.hue_names
         if box_plotter.plot_hues is None:
             cat1 = box1
             cat2 = box2
-            hue1 = None
-            hue2 = None
             label1 = '{}'.format(cat1)
             label2 = '{}'.format(cat2)
             valid = cat1 in group_names and cat2 in group_names
@@ -255,7 +281,8 @@ def add_stat_annotation(ax,
             hue2 = box2[1]
             label1 = '{}_{}'.format(cat1, hue1)
             label2 = '{}_{}'.format(cat2, hue2)
-            valid = cat1 in group_names and cat2 in group_names and hue1 in hue_names and hue2 in hue_names
+            valid = cat1 in group_names and cat2 in group_names and \
+                hue1 in hue_names and hue2 in hue_names
 
         if valid:
             # Get position of boxes
@@ -266,26 +293,33 @@ def add_stat_annotation(ax,
             ymax1 = box_data1.max()
             ymax2 = box_data2.max()
 
-            pval, formatted_output, test_short_name = stat_test(box_data1, box_data2, test)
-            test_result_list.append({'pvalue':pval, 'test_short_name':test_short_name,
-                                   'formatted_output':formatted_output, 'box1':box1, 'box2':box2})
+            pval, formatted_output, test_short_name = stat_test(
+                box_data1, box_data2, test, **stats_params)
+            test_result_list.append(
+                {'pvalue': pval, 'test_short_name': test_short_name,
+                 'formatted_output': formatted_output, 'box1': box1,
+                 'box2': box2})
             if verbose >= 1:
                 print("{} v.s. {}: {}".format(label1, label2, formatted_output))
 
             if text_format == 'full':
-                text = "{} p = {}".format('{}', pvalue_format_string).format(test_short_name, pval)
+                text = "{} p = {}".format('{}', pvalue_format_string).format(
+                    test_short_name, pval)
             elif text_format is None:
                 text = None
             elif text_format is 'star':
                 text = pval_annotation_text(pval, pvalue_thresholds)
-            elif text_format is 'simple':
+            # 'simple', see valid_list
+            else:
                 test_short_name = show_test_name and test_short_name or ""
-                text = simple_text(pval, simple_format_string, pvalue_thresholds,
-                                   test_short_name)
+                text = simple_text(
+                    pval, simple_format_string, pvalue_thresholds,
+                    test_short_name)
 
             if loc == 'inside':
                 yref = max(ymax1, ymax2)
-            elif loc == 'outside':
+            # 'outside', see valid_list
+            else:
                 yref = ylim[1]
 
             if stack:
@@ -301,24 +335,26 @@ def add_stat_annotation(ax,
             else:
                 y = yref2 + y_offset
             h = line_height*yrange
-            lineX, lineY = [x1, x1, x2, x2], [y, y + h, y + h, y]
+            line_x, line_y = [x1, x1, x2, x2], [y, y + h, y + h, y]
             if loc == 'inside':
-                ax.plot(lineX, lineY, lw=linewidth, c=color)
-            elif loc == 'outside':
-                line = lines.Line2D(lineX, lineY, lw=linewidth, c=color, transform=ax.transData)
+                ax.plot(line_x, line_y, lw=linewidth, c=color)
+            # 'outside', see valid_list
+            else:
+                line = lines.Line2D(
+                    line_x, line_y, lw=linewidth, c=color, transform=ax.transData)
                 line.set_clip_on(False)
                 ax.add_line(line)
-
-            if text is not None:
-                ann = ax.annotate(text, xy=(np.mean([x1, x2]), y + h),
-                                  xytext=(0, text_offset), textcoords='offset points',
-                                  xycoords='data', ha='center', va='bottom', fontsize=fontsize,
-                                  clip_on=False, annotation_clip=False)
-                annList.append(ann)
 
             ax.set_ylim((ylim[0], 1.1*(y + h)))
 
             if text is not None:
+                ann = ax.annotate(
+                    text, xy=(np.mean([x1, x2]), y + h),
+                    xytext=(0, text_offset), textcoords='offset points',
+                    xycoords='data', ha='center', va='bottom',
+                    fontsize=fontsize, clip_on=False, annotation_clip=False)
+                ann_list.append(ann)
+
                 plt.draw()
                 y_top_annot = None
                 got_mpl_error = False
@@ -332,19 +368,25 @@ def add_stat_annotation(ax,
 
                 if use_fixed_offset or got_mpl_error:
                     if verbose >= 1:
-                        print("Warning: cannot get the text bounding box. Falling back to a fixed y offset. Layout may be not optimal.")
-                    # We will apply a fixed offset in points, based on the font size of the annotation.
-                    fontsize_points = FontProperties(size='medium').get_size_in_points()
-                    offsetTrans = mtransforms.offset_copy(ax.transData, fig=fig,
-                                                          x=0, y=1.0*fontsize_points + text_offset, units='points')
-                    yTopDisplay = offsetTrans.transform((0, y + h))
-                    y_top_annot = ax.transData.inverted().transform(yTopDisplay)[1]
+                        print("Warning: cannot get the text bounding box. "
+                              "Falling back to a fixed y offset. "
+                              "Layout may be not optimal.")
+                    # We will apply a fixed offset in points, 
+                    # based on the font size of the annotation.
+                    fontsize_points = FontProperties(
+                        size='medium').get_size_in_points()
+                    offset_trans = mtransforms.offset_copy(
+                        ax.transData, fig=fig, x=0,
+                        y=1.0*fontsize_points + text_offset, units='points')
+                    y_top_display = offset_trans.transform((0, y + h))
+                    y_top_annot = ax.transData.inverted().transform(
+                        y_top_display)[1]
             else:
                 y_top_annot = y + h
 
             y_stack.append(y_top_annot)
         else:
-            raise ValueError("box_pairs contains an unvalid box pair.")
+            raise ValueError("box_pairs contains an invalid box pair.")
             pass
 
     y_stack_max = max(y_stack)

--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -18,9 +18,9 @@ def stat_test(box_data1, box_data2, test):
     formatted_output = None
     if test == 'Levene':
         stat, pval = stats.levene(box_data1, box_data2)
-        testShortName = 'levene'
-        formattedOutput = "Levene test of variance, P_val={:.3e} stat={:.3e}".format(pval, stat)
-    if test == 'Mann-Whitney':
+        test_short_name = 'levene'
+        formatted_output = "Levene test of variance, P_val={:.3e} stat={:.3e}".format(pval, stat)
+    elif test == 'Mann-Whitney':
         u_stat, pval = stats.mannwhitneyu(box_data1, box_data2, alternative='two-sided')
         test_short_name = 'M.W.W.'
         formatted_output = ("Mann-Whitney-Wilcoxon test two-sided P_val={:.3e} U_stat={:.3e}"
@@ -49,10 +49,10 @@ def stat_test(box_data1, box_data2, test):
         formatted_output = "t-test paired samples, P_val={:.3e} stat={:.3e}".format(pval, stat)
     elif test == 'Wilcoxon':
         zero_method = len(box_data1) <= 20 and "pratt" or "wilcox"
-        print(zero_method)
+        print("Using zero_method ", zero_method)
         stat, pval = stats.wilcoxon(box_data1, box_data2, zero_method=zero_method)
-        testShortName = 'Wilcoxon'
-        formattedOutput = "Wilcoxon test (paired samples), P_val={:.3e} stat={:.3e}".format(pval, stat)
+        test_short_name = 'Wilcoxon'
+        formatted_output = "Wilcoxon test (paired samples), P_val={:.3e} stat={:.3e}".format(pval, stat)
     return pval, formatted_output, test_short_name
 
 

--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -20,42 +20,42 @@ def stat_test(box_data1, box_data2, test, **stats_params):
     if test == 'Levene':
         stat, pval = stats.levene(box_data1, box_data2, **stats_params)
         test_short_name = 'levene'
-        formatted_output = "Levene test of variance, " \
-                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = ("Levene test of variance, "
+                            "P_val={:.3e} stat={:.3e}").format(pval, stat)
     elif test == 'Mann-Whitney':
         u_stat, pval = stats.mannwhitneyu(
             box_data1, box_data2, alternative='two-sided', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = "Mann-Whitney-Wilcoxon test two-sided " \
-                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
+        formatted_output = ("Mann-Whitney-Wilcoxon test two-sided "
+                            "P_val={:.3e} U_stat={:.3e}").format(pval, u_stat)
     elif test == 'Mann-Whitney-gt':
         u_stat, pval = stats.mannwhitneyu(
             box_data1, box_data2, alternative='greater', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = "Mann-Whitney-Wilcoxon test greater " \
-                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
+        formatted_output = ("Mann-Whitney-Wilcoxon test greater "
+                            "P_val={:.3e} U_stat={:.3e}").format(pval, u_stat)
     elif test == 'Mann-Whitney-ls':
         u_stat, pval = stats.mannwhitneyu(
             box_data1, box_data2, alternative='less', **stats_params)
         test_short_name = 'M.W.W.'
-        formatted_output = "Mann-Whitney-Wilcoxon test smaller " \
-                           "P_val={:.3e} U_stat={:.3e}".format(pval, u_stat)
+        formatted_output = ("Mann-Whitney-Wilcoxon test smaller "
+                            "P_val={:.3e} U_stat={:.3e}").format(pval, u_stat)
     elif test == 't-test_ind':
         stat, pval = stats.ttest_ind(a=box_data1, b=box_data2, **stats_params)
         test_short_name = 't-test_ind'
-        formatted_output = "t-test independent samples, " \
-                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = ("t-test independent samples, "
+                            "P_val={:.3e} stat={:.3e}").format(pval, stat)
     elif test == 't-test_welch':
         stat, pval = stats.ttest_ind(
             a=box_data1, b=box_data2, equal_var=False, **stats_params)
         test_short_name = 't-test_welch'
-        formatted_output = "Welch's t-test independent samples, " \
-                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = ("Welch's t-test independent samples, "
+                            "P_val={:.3e} stat={:.3e}").format(pval, stat)
     elif test == 't-test_paired':
         stat, pval = stats.ttest_rel(a=box_data1, b=box_data2, **stats_params)
         test_short_name = 't-test_rel'
-        formatted_output = "t-test paired samples, " \
-                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = ("t-test paired samples, "
+                            "P_val={:.3e} stat={:.3e}").format(pval, stat)
     elif test == 'Wilcoxon':
         if "zero_method" in stats_params.keys():
             zero_method = stats_params["zero_method"]
@@ -66,8 +66,8 @@ def stat_test(box_data1, box_data2, test, **stats_params):
         stat, pval = stats.wilcoxon(
             box_data1, box_data2, zero_method=zero_method, **stats_params)
         test_short_name = 'Wilcoxon'
-        formatted_output = "Wilcoxon test (paired samples), " \
-                           "P_val={:.3e} stat={:.3e}".format(pval, stat)
+        formatted_output = ("Wilcoxon test (paired samples), "
+                            "P_val={:.3e} stat={:.3e}").format(pval, stat)
     return pval, formatted_output, test_short_name
 
 
@@ -130,15 +130,16 @@ def add_stat_annotation(ax,
                         stack=True, color='0.2', linewidth=1.5,
                         fontsize='medium', verbose=1):
     """
-    User should use the same argument for the data, x, y, hue, order, hue_order
-    as the seaborn boxplot function.
+    User should use the same argument for the data, x, y, hue, order,
+    hue_order as the seaborn boxplot function.
 
     line_height is in axes fraction coordinates.
     text_offset is in points.
 
     box_pairs can be of either form:
     For non-grouped boxplot: [(cat1, cat2), (cat3, cat4)]
-    For boxplot grouped by hue: [((cat1, hue1), (cat2, hue2)), ((cat3, hue3), (cat4, hue4))]
+    For boxplot grouped by hue:
+    [((cat1, hue1), (cat2, hue2)), ((cat3, hue3), (cat4, hue4))]
 
     Default pvalue_format_string is "{.3e}".
     pvalue_thresholds is a list of lists or tuples. Default is:
@@ -158,7 +159,8 @@ def add_stat_annotation(ax,
         else:
             cat = boxName[0]
             hue = boxName[1]
-            hue_offset = box_plotter.hue_offsets[box_plotter.hue_names.index(hue)]
+            hue_offset = box_plotter.hue_offsets[
+                box_plotter.hue_names.index(hue)]
 
         group_pos = box_plotter.group_names.index(cat)
         box_pos = group_pos + hue_offset
@@ -214,8 +216,9 @@ def add_stat_annotation(ax,
         raise ValueError(
             "text_format value should be one of the following: {}.".format(
                 ', '.join(valid_list)))
-    valid_list = ['t-test_ind', 't-test_welch', 't-test_paired', 'Mann-Whitney',
-                  'Mann-Whitney-gt', 'Mann-Whitney-ls', 'Levene', 'Wilcoxon']
+    valid_list = ['t-test_ind', 't-test_welch', 't-test_paired',
+                  'Mann-Whitney', 'Mann-Whitney-gt', 'Mann-Whitney-ls',
+                  'Levene', 'Wilcoxon']
     if test not in valid_list:
         raise ValueError(
             "test value should be one of the following: {}.".format(
@@ -236,11 +239,9 @@ def add_stat_annotation(ax,
         print()
 
     # Create the same BoxPlotter object as seaborn's boxplot
-    box_plotter = sns.categorical._BoxPlotter(x, y, hue, data, order, hue_order,
-                                              orient=None, width=.8, color=None,
-                                              palette=None, saturation=.75,
-                                              dodge=True, fliersize=5,
-                                              linewidth=None)
+    box_plotter = sns.categorical._BoxPlotter(
+        x, y, hue, data, order, hue_order, orient=None, width=.8, color=None,
+        palette=None, saturation=.75, dodge=True, fliersize=5, linewidth=None)
 
     ylim = ax.get_ylim()
     yrange = ylim[1] - ylim[0]
@@ -304,7 +305,8 @@ def add_stat_annotation(ax,
                  'formatted_output': formatted_output, 'box1': box1,
                  'box2': box2})
             if verbose >= 1:
-                print("{} v.s. {}: {}".format(label1, label2, formatted_output))
+                print("{} v.s. {}: {}".format(
+                    label1, label2, formatted_output))
 
             if text_format == 'full':
                 text = "{} p = {}".format('{}', pvalue_format_string).format(
@@ -345,7 +347,8 @@ def add_stat_annotation(ax,
             # 'outside', see valid_list
             else:
                 line = lines.Line2D(
-                    line_x, line_y, lw=linewidth, c=color, transform=ax.transData)
+                    line_x, line_y, lw=linewidth, c=color,
+                    transform=ax.transData)
                 line.set_clip_on(False)
                 ax.add_line(line)
 


### PR DESCRIPTION
Levene test of variance and Wilcoxon test for paired samples are added.

The optional `stats_params` parameter for `add_stat_annotation` (passed to `stat_test`) allows to specify arguments for the statistical tests. Should be a dictionary.

I also reformatted to follow PEP8 conventions more closely for variable names and line length.

Finally, there were unused imports which I commented or deleted.