### PR TITLE
support boxName being falsy values like 0

### DIFF
--- a/statannot/statannot.py
+++ b/statannot/statannot.py
@@ -323,7 +323,7 @@ def add_stat_annotation(ax, plot='boxplot',
         Here we really have to duplicate seaborn code, because there is not
         direct access to the box_data in the BoxPlotter class.
         """
-        cat = box_plotter.plot_hues is None and boxName or boxName[0]
+        cat = boxName if box_plotter.plot_hues is None else boxName[0]
 
         index = box_plotter.group_names.index(cat)
         group_data = box_plotter.plot_data[index]


### PR DESCRIPTION
If `box_name` in `get_box_data` is a **falsy** value, such as `0`, `cat = box_plotter.plot_hues is None and boxName or boxName[0]` (at [here](https://github.com/webermarcolivier/statannot/blob/9b9c6c44505f7dd15376f7df8d9fd1ac1c395aa5/statannot/statannot.py#L326)) will fail due to the short-circuiting of `and` and `or`.